### PR TITLE
ADD : requirements 문서 의존성 추가

### DIFF
--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+pymysql
+python-dotenv
+feedparser
+requests
+sentence-transformers
+scikit-learn


### PR DESCRIPTION
requirements 문서에 의존성을 더 추가했습니다.
패키지 다운 시 터미널에
`pip install -r requirements.txt`
작성하면 됩니다.