### PR TITLE
화면 재배치, 로그인, 지식맵 구현(#28)

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,37 @@
+// src/components/ui/Header.tsx
+import { useNavigate } from "react-router-dom";
+
+export default function Header() {
+  const navigate = useNavigate();
+  const token = localStorage.getItem("access_token");
+
+  const handleLogout = () => {
+    localStorage.removeItem("access_token");
+    alert("로그아웃 되었습니다.");
+    navigate("/login");
+  };
+
+  const handleLogin = () => {
+    navigate("/login");
+  };
+
+  return (
+    <div className="w-full flex justify-end px-6 py-4">
+      {token ? (
+        <button
+          onClick={handleLogout}
+          className="text-sm px-3 py-1 bg-blue-400 hover:bg-blue-500 text-white font-semibold rounded-md"
+        >
+          로그아웃
+        </button>
+      ) : (
+        <button
+          onClick={handleLogin}
+          className="text-sm bg-blue-400 hover:bg-blue-500 text-white font-semibold rounded-md px-3 py-1 "
+        >
+          로그인
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/KeywordGraph.tsx
+++ b/frontend/src/components/KeywordGraph.tsx
@@ -1,9 +1,10 @@
+// 📄 src/components/KeywordGraph.tsx
 import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import * as d3 from "d3";
 import type { Keyword } from "@/types/keyword";
 import type { PCluster } from "@/types/cluster";
 import type { D3DragEvent } from "d3";
-
 
 type Node = {
   id: number;
@@ -28,6 +29,7 @@ type Props = {
 
 export function KeywordGraph({ clusters }: Props) {
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!svgRef.current) return;
@@ -77,31 +79,35 @@ export function KeywordGraph({ clusters }: Props) {
       .join("line")
       .attr("stroke-width", 1.5);
 
-const node = (svg
-  .append("g")
-  .selectAll<SVGCircleElement, Node>("circle")
-  .data(nodes)
-  .join("circle")
-  .attr("r", 12)
-  .attr("fill", (d) => d3.schemeCategory10[d.clusterId % 10]) as d3.Selection<SVGCircleElement, Node, SVGGElement, unknown>
-).call(
-  d3
-    .drag<SVGCircleElement, Node>()
-    .on("start", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-      if (!event.active) simulation.alphaTarget(0.3).restart();
-      d.fx = d.x;
-      d.fy = d.y;
-    })
-    .on("drag", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-      d.fx = event.x;
-      d.fy = event.y;
-    })
-    .on("end", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-      if (!event.active) simulation.alphaTarget(0);
-      d.fx = null;
-      d.fy = null;
-    })
-);
+    const node = svg
+      .append("g")
+      .selectAll<SVGCircleElement, Node>("circle")
+      .data(nodes)
+      .join("circle")
+      .attr("r", 12)
+      .attr("fill", (d) => d3.schemeCategory10[d.clusterId % 10])
+      .style("cursor", "pointer")
+      .on("click", (event, d) => {
+        navigate(`/keywords/${d.id}`);
+      })
+      .call(
+        d3
+          .drag<SVGCircleElement, Node>()
+          .on("start", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
+            if (!event.active) simulation.alphaTarget(0.3).restart();
+            d.fx = d.x;
+            d.fy = d.y;
+          })
+          .on("drag", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
+            d.fx = event.x;
+            d.fy = event.y;
+          })
+          .on("end", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
+            if (!event.active) simulation.alphaTarget(0);
+            d.fx = null;
+            d.fy = null;
+          })
+      );
 
     const labels = svg
       .append("g")
@@ -127,7 +133,7 @@ const node = (svg
     return () => {
       simulation.stop();
     };
-  }, [clusters]);
+  }, [clusters, navigate]);
 
   return <svg ref={svgRef} width={600} height={400} className="mx-auto my-4" />;
 }

--- a/frontend/src/components/NoteEditSheet.tsx
+++ b/frontend/src/components/NoteEditSheet.tsx
@@ -1,0 +1,88 @@
+// 📄 src/components/NoteEditSheet.tsx
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import type { Note } from "@/types/note";
+import type { Article } from "@/types/article";
+import React from "react";
+
+interface NoteEditSheetProps {
+  open: boolean;
+  note: Note | null;
+  articles: Article[];
+  onClose: () => void;
+  onChange: (note: Note) => void;
+  onSave: () => void;
+}
+
+export default function NoteEditSheet({
+  open,
+  note,
+  articles,
+  onClose,
+  onChange,
+  onSave,
+}: NoteEditSheetProps) {
+  if (!note) return null;
+
+  return (
+    <Sheet open={open}>
+      <SheetContent>
+        <SheetHeader className="mb-4">
+          <SheetTitle>노트</SheetTitle>
+        </SheetHeader>
+        <div className="flex flex-col gap-4">
+          <input
+            type="text"
+            className="border p-6 h-[40px] rounded w-full text-base"
+            value={note.title || ""}
+            onChange={(e) => onChange({ ...note, title: e.target.value })}
+          />
+          <textarea
+            className="border p-4 rounded w-full h-[400px] resize-none text-base"
+            value={note.text || ""}
+            onChange={(e) => onChange({ ...note, text: e.target.value })}
+          />
+
+          <div className="mt-8">
+            <h3 className="font-semibold mb-2">연관 기사</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              {articles.map((article) => (
+                <li key={article.id}>
+                  <a
+                    href={article.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    {article.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <SheetFooter className="mt-6 flex justify-between">
+          <button
+            onClick={onSave}
+            className="text-sm bg-blue-400 hover:bg-blue-500 text-white font-semibold rounded-md"
+          >
+            SAVE
+          </button>
+          <button
+            onClick={onClose}
+            className="bg-blue-400 hover:bg-blue-500 text-white font-semibold rounded-md px-4 py-2 "
+          >
+            CLOSE
+          </button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,12 +8,12 @@ import { getScrappedArticles } from "@/services/scrap";
 import { fetchLatestKnowledgeMap } from "@/services/knowledgeMap";
 import type { Note } from "@/types/note";
 import type { ScrappedArticle } from "@/types/scrap";
-import type { Keyword } from "@/types/keyword";
 import type { KnowledgeMap } from "@/types/knowledgeMap";
 import { KeywordGraph } from "@/components/KeywordGraph";
-import {Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
+import Header from "@/components/Header";
+
 export default function DashboardPage() {
-  const userId = 1;
   const navigate = useNavigate();
 
   const [notes, setNotes] = useState<Note[]>([]);
@@ -24,9 +24,8 @@ export default function DashboardPage() {
   useEffect(() => {
     Promise.all([
       getNotesByPage(1, 3).then((res) => setNotes(res.notes)),
-      getScrappedArticles({ userId, page: 1, size: 5 }).then((res) => setScraps(res.articles)),
-      fetchLatestKnowledgeMap(userId).then((res) => {
-        // Transform the response to match KnowledgeMap type if needed
+      getScrappedArticles({ page: 1, size: 5 }).then((res) => setScraps(res.articles)),
+      fetchLatestKnowledgeMap().then((res) => {
         if (res && 'keywords' in res) {
           setMap({
             id: res.id,
@@ -50,87 +49,87 @@ export default function DashboardPage() {
   }
 
   return (
-  <div className="flex min-h-screen bg-white gap-x-8">
-    {/* 1. 로고 영역 (왼쪽 세로 고정) */}
-    <div className="w-[120px] border-r px-4 py-8 flex justify-center">
-      <Logo />
-    </div>
-
-    {/* 2. 지식맵 + 스크랩 영역 (세로 정렬) */}
-    <div className="w-[300px] border-r px-6 py-8 flex flex-col gap-10">
-      {/* 지식맵 */}
-      <div>
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="font-bold text-lg">MY KNOWLEDGE-MAP</h2>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => navigate("/note")}
-            className="text-xs text-blue-600 px-2 py-1"
-          >
-            more+
-          </Button>
+    <div className="min-h-screen bg-white">
+      {/* ✅ 상단 헤더 */}
+      <header className="relative bg-sky-400 h-20 flex items-center px-6">
+        <div className="absolute left-6 top-1/2 transform -translate-y-1/2">
+          <Logo />
         </div>
-        {map?.clusters?.length && map.clusters.length > 0 ? (
-          <KeywordGraph clusters={map.clusters.map((c) => ({ ...c, label: String(c.label) }))} />
-        ) : (
-          <p className="text-sm text-gray-500">지식맵이 없습니다.</p>
-        )}
-      </div>
-
-      {/* 스크랩 */}
-      <div>
-        <div className="flex items-center justify-between mb-2">
-          <h2 className="font-bold text-lg">SCRAP</h2>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => navigate("/scrapbook")}
-            className="text-xs text-blue-600 px-2 py-1"
-          >
-            more+
-          </Button>
+        <h1 className="text-white text-xl font-bold mx-auto">DASHBOARD</h1>
+        <div className="px-2 py -1">
+          <Header />
         </div>
-        <div className="space-y-1 text-sm text-blue-600">
-          {scraps.map((s) => (
-            <a
-              key={s.id}
-              href={s.link}
-              target="_blank"
-              rel="noreferrer"
-              className="block hover:underline"
+      </header>
+
+      {/* ✅ 본문 (세로 정렬) */}
+      <main className="px-6 py-10 flex flex-col items-center gap-10">
+        {/* ✅ 지식맵 */}
+        <section className="w-full max-w-4xl">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="font-bold text-lg">MY KNOWLEDGE-MAP</h2>
+          </div>
+          <div className="bg-gray-50 border rounded px-4 py-3">
+            {map?.clusters?.length && map.clusters.length > 0 ? (
+              <KeywordGraph clusters={map.clusters.map((c) => ({ ...c, label: String(c.label) }))} />
+            ) : (
+              <p className="text-sm text-gray-500">지식맵이 없습니다.</p>
+            )}
+          </div>
+        </section>
+
+        {/* ✅ 스크랩 */}
+        <section className="w-full max-w-4xl">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="font-bold text-lg">SCRAP</h2>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate("/users/scraps")}
+              className="text-xs text-blue-600 px-2 py-1"
             >
-              {s.title}
-            </a>
-          ))}
-          {scraps.length === 0 && (
-            <p className="text-gray-500">스크랩된 기사가 없습니다.</p>
-          )}
-        </div>
-      </div>
+              more+
+            </Button>
+          </div>
+          <div className="bg-gray-50 border rounded px-4 py-3 space-y-1 text-sm text-blue-600">
+            {scraps.map((s) => (
+              <a
+                key={s.id}
+                href={s.link}
+                target="_blank"
+                rel="noreferrer"
+                className="block hover:underline"
+              >
+                {s.title}
+              </a>
+            ))}
+            {scraps.length === 0 && (
+              <p className="text-gray-500">스크랩된 기사가 없습니다.</p>
+            )}
+          </div>
+        </section>
+
+        {/* ✅ 노트 */}
+        <section className="w-full max-w-4xl">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="font-bold text-lg">NOTE</h2>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate("/users/notes")}
+              className="text-xs text-blue-600 px-2 py-1"
+            >
+              more+
+            </Button>
+          </div>
+          <div className="bg-gray-50 border rounded px-4 py-3">
+            {notes.length > 0 ? (
+              <NoteAccordionList notes={notes} onSelect={() => {}} />
+            ) : (
+              <p className="text-sm text-gray-500">작성된 노트가 없습니다.</p>
+            )}
+          </div>
+        </section>
+      </main>
     </div>
-
-    {/* 3. NOTE 영역 (오른쪽 전체 공간) */}
-    <div className="flex-1 px-12 py-10">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Note</h1>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => navigate("/note")}
-          className="text-xs text-blue-600 px-2 py-1"
-        >
-          more+
-        </Button>
-      </div>
-
-      {notes.length > 0 ? (
-        <NoteAccordionList notes={notes} onSelect={() => {}} />
-      ) : (
-        <p className="text-sm text-gray-500">작성된 노트가 없습니다.</p>
-      )}
-    </div>
-  </div>
-);
-
+  );
 }

--- a/frontend/src/pages/KeywordDetailPage.tsx
+++ b/frontend/src/pages/KeywordDetailPage.tsx
@@ -1,0 +1,106 @@
+// 📄 src/pages/KeywordDetailPage.tsx
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { fetchNotesByKeywordCluster, fetchArticlesByKeywordCluster, fetchKeywordName } from "@/services/knowledgeMap";
+import type { Note } from "@/types/note";
+import type { Article } from "@/types/article";
+import { Button } from "@/components/ui/button";
+import Logo from "@/components/ui/logo";
+import { ArrowRight, Star } from "lucide-react";
+import PaginationComponent from "@/components/PaginationComponent";
+import Header from "@/components/Header";
+export default function KeywordDetailPage() {
+  const { keywordId } = useParams();
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [keywordName, setKeywordName] = useState<string>("");
+
+  const [notePage, setNotePage] = useState(1);
+  const [articlePage, setArticlePage] = useState(1);
+  const [noteTotalPages, setNoteTotalPages] = useState(1);
+  const [articleTotalPages, setArticleTotalPages] = useState(1);
+
+  useEffect(() => {
+    if (!keywordId) return;
+
+    fetchKeywordName(Number(keywordId)).then((res) => setKeywordName(res.name));
+
+    fetchNotesByKeywordCluster(Number(keywordId)).then((res) => {
+      setNotes(res);
+      // If you have totalPages info, update this accordingly; otherwise, remove or set to 1
+      setNoteTotalPages(1);
+    });
+
+    fetchArticlesByKeywordCluster(Number(keywordId)).then((res) => {
+      setArticles(res);
+      // If you have totalPages info, update this accordingly; otherwise, remove or set to 1
+      setArticleTotalPages(1);
+    });
+  }, [keywordId, notePage, articlePage]);
+
+  return (
+    <div className="min-h-screen bg-white px-10 py-8">
+      <header className="flex items-center justify-between mb-10">
+        <Logo />
+        <span className="text-sm font-medium text-blue-600 border border-blue-600 rounded-full px-2 py-6">
+          {keywordName}
+        </span>
+        <div className="px-2 py -1">
+                  <Header />
+                </div>
+      </header>
+
+      <main className="flex gap-20">
+        {/* NOTE 영역 */}
+        <section className="flex-1">
+          <h2 className="text-2xl font-bold mb-6">NOTE</h2>
+          <ul className="space-y-6">
+            {notes.map((note) => (
+              <li key={note.id} className="flex items-center justify-between">
+                <div>
+                  <div className="flex items-center gap-2 font-medium">
+                    <Star className="w-4 h-4 text-blue-500" /> {note.title}
+                  </div>
+                  <p className="text-sm text-gray-500">{note.text}</p>
+                </div>
+                <ArrowRight className="w-6 h-6 text-blue-500" />
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6">
+            <PaginationComponent
+              currentPage={notePage}
+              totalPages={noteTotalPages}
+              onPageChange={setNotePage}
+            />
+          </div>
+        </section>
+
+        {/* SCAP 영역 */}
+        <section className="flex-1">
+          <h2 className="text-2xl font-bold mb-6">SCAP</h2>
+          {articles.length > 0 ? (
+            <ul className="space-y-3 text-sm text-blue-600">
+              {articles.map((article) => (
+                <li key={article.id}>
+                  <a href={article.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                    {article.link}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">스크랩된 기사가 없습니다.</p>
+          )}
+          <div className="mt-6">
+            <PaginationComponent
+              currentPage={articlePage}
+              totalPages={articleTotalPages}
+              onPageChange={setArticlePage}
+            />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/KeywordDetailPagePreview.tsx
+++ b/frontend/src/pages/KeywordDetailPagePreview.tsx
@@ -1,0 +1,104 @@
+// 📄 src/pages/KeywordDetailPagePreview.tsx
+import { useState } from "react";
+import type { Note } from "@/types/note";
+import type { Article } from "@/types/article";
+import { Button } from "@/components/ui/button";
+import Logo from "@/components/ui/logo";
+import Header from "@/components/Header";
+import { ArrowRight, Star } from "lucide-react";
+import PaginationComponent from "@/components/PaginationComponent";
+
+export default function KeywordDetailPagePreview() {
+  const [notes, setNotes] = useState<Note[]>([
+    { id: "1", title: "AI 요약 노트", text: "ChatGPT가 정리한 내용입니다.", createdAt: "2024-06-01" },
+    { id: "2", title: "AI 시대", text: "AI의 영향과 기술 발전.", createdAt: "2024-06-02" },
+  ]);
+  const [articles, setArticles] = useState<Article[]>([
+    {
+      id: 1,
+      title: "AI 윤리 논쟁",
+      link: "https://example.com/ai-ethics",
+      summary: "AI 윤리 논쟁에 대한 요약입니다.",
+      published: "2024-06-01"
+    },
+    {
+      id: 2,
+      title: "AI 기술 흐름",
+      link: "https://example.com/ai-tech",
+      summary: "AI 기술의 최신 흐름을 다룹니다.",
+      published: "2024-06-02"
+    },
+  ]);
+
+  const [keywordName, setKeywordName] = useState("AI 기술");
+  const [notePage, setNotePage] = useState(1);
+  const [articlePage, setArticlePage] = useState(1);
+  const [noteTotalPages] = useState(2);
+  const [articleTotalPages] = useState(2);
+
+  return (
+    <div className="min-h-screen bg-white px-10 py-8">
+      <header className="flex items-center justify-between mb-10">
+        <Logo />
+        <span className="text-sm font-medium text-blue-600 border border-blue-600 rounded-full px-2 py-1">
+          {keywordName}
+        </span>
+        <div className="px-2 py-1">
+          <Header />
+        </div>
+      </header>
+
+      <main className="flex gap-20">
+        {/* NOTE 영역 */}
+        <section className="flex-1">
+          <h2 className="text-2xl font-bold mb-6">NOTE</h2>
+          <ul className="space-y-6">
+            {notes.map((note) => (
+              <li key={note.id} className="flex items-center justify-between">
+                <div>
+                  <div className="flex items-center gap-2 font-medium">
+                    <Star className="w-4 h-4 text-blue-500" /> {note.title}
+                  </div>
+                  <p className="text-sm text-gray-500">{note.text}</p>
+                </div>
+                <ArrowRight className="w-6 h-6 text-blue-500" />
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6">
+            <PaginationComponent
+              currentPage={notePage}
+              totalPages={noteTotalPages}
+              onPageChange={setNotePage}
+            />
+          </div>
+        </section>
+
+        {/* SCAP 영역 */}
+        <section className="flex-1">
+          <h2 className="text-2xl font-bold mb-6">SCAP</h2>
+          {articles.length > 0 ? (
+            <ul className="space-y-3 text-sm text-blue-600">
+              {articles.map((article) => (
+                <li key={article.id}>
+                  <a href={article.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                    {article.link}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">스크랩된 기사가 없습니다.</p>
+          )}
+          <div className="mt-6">
+            <PaginationComponent
+              currentPage={articlePage}
+              totalPages={articleTotalPages}
+              onPageChange={setArticlePage}
+            />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/KeywordGraphPreview.tsx
+++ b/frontend/src/pages/KeywordGraphPreview.tsx
@@ -1,0 +1,33 @@
+// 📄 src/pages/KeywordGraphPreview.tsx
+import { KeywordGraph } from "@/components/KeywordGraph";
+import type { PCluster } from "@/types/cluster";
+
+const dummyClusters: PCluster[] = [
+  {
+    id: 0,
+    label: 1,
+    keywords: [
+      { id: 1, name: "AI" },
+      { id: 2, name: "ChatGPT" },
+      { id: 3, name: "딥러닝" },
+    ],
+  },
+  {
+    id: 1,
+    label: 2,
+    keywords: [
+      { id: 4, name: "선거" },
+      { id: 5, name: "정치" },
+      { id: 6, name: "후보" },
+    ],
+  },
+];
+
+export default function KeywordGraphPreview() {
+  return (
+    <div className="min-h-screen bg-white p-10">
+      <h1 className="text-xl font-bold text-center mb-6">Keyword Graph Preview</h1>
+      <KeywordGraph clusters={dummyClusters} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,25 +1,72 @@
 import { useState } from "react";
-import api from "../services/api";
+import { useNavigate } from "react-router-dom";
+import Logo from "@/components/ui/logo";
+import { login } from "@/services/auth"; // 👈 로그인 API 함수만 사용
 
 export default function Login() {
-  const [username, setUsername] = useState("");
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  const handleLogin = async () => {
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
     try {
-      const res = await api.post("/auth/login", { username, password });
+      const res = await login(email, password); // ✅ 서비스 함수 호출
+      localStorage.setItem("access_token", res.access_token); // ✅ 토큰 저장
       alert("로그인 성공!");
-    } catch (err) {
-      alert("로그인 실패!");
+      navigate("/dashboard"); // 로그인 후 이동
+    } catch (err: any) {
+      console.error("로그인 오류:", err);
+      alert("로그인 실패! 이메일 또는 비밀번호를 확인하세요.");
     }
   };
 
   return (
-    <div>
-      <h2>로그인</h2>
-      <input placeholder="Username" onChange={(e) => setUsername(e.target.value)} />
-      <input type="password" placeholder="Password" onChange={(e) => setPassword(e.target.value)} />
-      <button onClick={handleLogin}>Login</button>
+    <div className="relative min-h-screen bg-white">
+      {/* 좌측 상단 로고 */}
+      <div className="absolute top-4 left-4">
+        <Logo />
+      </div>
+
+      {/* 로그인 폼 */}
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <h1 className="text-2xl font-bold text-[#78AAFB] mb-6">로그인</h1>
+        <form onSubmit={handleLogin} className="flex flex-col w-[300px] gap-3">
+          {/* 이메일 */}
+          <label className="text-sm text-gray-600 font-semibold">
+            이메일
+            <input
+              type="text"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full mt-1 p-2 border rounded-md text-sm outline-none focus:ring-2 focus:ring-blue-300"
+            />
+          </label>
+
+          {/* 비밀번호 */}
+          <label className="text-sm text-gray-600 font-semibold">
+            비밀번호
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full mt-1 p-2 border rounded-md text-sm outline-none focus:ring-2 focus:ring-blue-300"
+            />
+          </label>
+          
+
+          {/* 로그인 버튼 */}
+          <button
+            type="submit"
+            className="mt-10 p-2 bg-blue-400 hover:bg-blue-500 text-white font-semibold rounded-md"
+          >
+            로그인
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/NoteEditSheetPreview.tsx
+++ b/frontend/src/pages/NoteEditSheetPreview.tsx
@@ -1,0 +1,49 @@
+// src/pages/NoteEditSheetPreview.tsx
+import { useState } from "react";
+import NoteEditSheet from "@/components/NoteEditSheet";
+import type { Note } from "@/types/note";
+import type { Article } from "@/types/article";
+
+export default function NoteEditSheetPreview() {
+  const [open, setOpen] = useState(true);
+
+  const [note, setNote] = useState<Note>({
+    id: "1",
+    title: "AI 요약 정리",
+    text: "ChatGPT가 요약해준 기사 내용입니다.",
+    createdAt: "2023-10-01",
+  });
+
+  const [articles, setArticles] = useState<Article[]>([
+    {
+      id: 1,
+      title: "ChatGPT 활용법 총정리",
+      summary: "ChatGPT를 활용하는 방법에 대한 기사입니다.",
+      published: "2023-10-01",
+      link: "https://example.com/article1",
+    },
+    {
+      id: 2,
+      title: "AI 시대의 윤리 문제",
+      summary: "AI 시대에 발생할 수 있는 윤리 문제에 대한 기사입니다.",
+    published: "2023-10-02",
+      link: "https://example.com/article2",
+    },
+  ]);
+
+  const handleSave = () => {
+    alert("저장되었습니다!");
+    setOpen(false);
+  };
+
+  return (
+    <NoteEditSheet
+      open={open}
+      note={note}
+      articles={articles}
+      onClose={() => setOpen(false)}
+      onChange={(n) => setNote(n)}
+      onSave={handleSave}
+    />
+  );
+}

--- a/frontend/src/pages/ScrapbookPage.tsx
+++ b/frontend/src/pages/ScrapbookPage.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import PaginationComponent from "@/components/PaginationComponent";
 import Logo from "@/components/ui/logo";
+import Header from "@/components/Header";
 
 type Article = {
   id: number;
@@ -17,8 +18,6 @@ export default function ScrapbookPage() {
   const [keyword, setKeyword] = useState("");
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  
-
   const userId = 1; // ✅ 로그인 유저 아이디 (임시)
 
   const fetchScrapArticles = async () => {
@@ -42,18 +41,21 @@ export default function ScrapbookPage() {
   };
 
   return (
-    <div className="min-h-screen flex bg-white">
-      {/* ✅ 왼쪽 로고 영역 */}
-      <div className="w-[200px] p-6 border-r flex flex-col items-center">
-        <Logo />
-      </div>
+    <div className="min-h-screen bg-white">
+      {/* ✅ 상단 헤더 */}
+      <header className="relative bg-sky-400 h-20 flex items-center px-6">
+        <div className="px-2 py-1">
+          <Logo />
+        </div>
+        <h1 className="text-white text-xl font-bold mx-auto">SCRAPBOOK</h1>
+        <div className="px-2 py -1">
+          <Header />
+        </div>
+      </header>
 
-      {/* ✅ 오른쪽 콘텐츠 영역 */}
-      <div className="flex-1 px-10 py-10 flex flex-col items-center">
-        <div className="w-full max-w-5xl bg-[#ebf2ff] rounded-lg p-12 flex flex-col items-center gap-8">
-          <div className="text-[32px] font-bold text-gray-800 tracking-tight">
-            SCRAPBOOK
-          </div>
+      {/* ✅ 본문 */}
+      <main className="px-6 py-10 flex flex-col items-center">
+        <div className="w-full max-w-4xl bg-[#ebf2ff] rounded-lg p-10 flex flex-col items-center gap-6">
           <p className="text-gray-500 text-center text-[16px]">
             기사 제목을 입력하세요
           </p>
@@ -68,7 +70,7 @@ export default function ScrapbookPage() {
           </div>
         </div>
 
-        <div className="w-full max-w-5xl mt-10 space-y-2">
+        <div className="w-full max-w-4xl mt-10 space-y-2">
           {articles.map((a) => (
             <div key={a.id} className="text-blue-600 hover:underline">
               <a href={a.link} target="_blank" rel="noopener noreferrer">
@@ -85,7 +87,7 @@ export default function ScrapbookPage() {
             onPageChange={setPage}
           />
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/routes/AppRouter.tsx
+++ b/frontend/src/routes/AppRouter.tsx
@@ -8,6 +8,10 @@ import ClusterDetailPage from "@/pages/ClusterDetailPage";
 
 import ScrapbookPage from "@/pages/ScrapbookPage";  //스크랩 페이지
 import DashboardPage from "@/pages/DashboardPage"; // 대시보드 페이지 import
+import NoteEditSheetPreview from "@/pages/NoteEditSheetPreview";
+import KeywordDetailPage from "@/pages/KeywordDetailPage"; // 지식맵 키워드 상세 페이지 
+import KeywordDetailPagePreview from "@/pages/KeywordDetailPagePreview";
+import KeywordGraphPreview from "@/pages/KeywordGraphPreview";
 export default function AppRouter() {
   return (
     <Router>
@@ -21,6 +25,10 @@ export default function AppRouter() {
         <Route path="/cluster/:clusterId" element={<ClusterDetailPage />} />
         <Route path="/users/scraps" element={<ScrapbookPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/users/notes/:noteId" element={<NoteEditSheetPreview />} />
+        <Route path="/keywords/:keywordId" element={<KeywordDetailPage />} />
+        <Route path="/keyword-detail-preview" element={<KeywordDetailPagePreview />} />
+        <Route path="/keyword-graph-preview" element={<KeywordGraphPreview />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -5,4 +5,13 @@ const api = axios.create({
   withCredentials: true,
 });
 
+// 요청 시 access token을 Authorization 헤더에 자동 포함
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("access_token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default api;

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,6 @@
+import api from "./api";
+
+export const login = async (email: string, password: string) => {
+  const res = await api.post("/auth/login", { email, password });
+  return res.data; // access_token 포함
+};

--- a/frontend/src/services/knowledgeMap.ts
+++ b/frontend/src/services/knowledgeMap.ts
@@ -1,31 +1,39 @@
 // src/services/knowledgeMap.ts
-
+import api from "./api";
 import type { Note } from "@/types/note";
 import type { Article } from "@/types/article";
-import type { PCluster } from "@/types/cluster";
-import type { Keyword } from "@/types/keyword";
-import type { KnowledgeMap } from "@/types/knowledgeMap";
 
-// ✅ 최신 Knowledge Map 하나 가져오기
-export async function fetchLatestKnowledgeMap(userId: number): Promise<{
+/**
+ * ✅ 최신 Knowledge Map 하나 가져오기
+ * 서버가 JWT 토큰에서 user_id 추출해야 함
+ */
+export async function fetchLatestKnowledgeMap(): Promise<{
   id: number;
   keywords: { id: number; name: string }[];
 }> {
-  const res = await fetch(`/api/users/${userId}/knowledge_maps/graph`);
-  if (!res.ok) throw new Error("지식맵 불러오기 실패");
-  return res.json();
+  const res = await api.get("/users/knowledge_maps/graph"); // ✅ userId 제거
+  return res.data;
 }
 
-// ✅ 해당 키워드를 제목으로 갖는 노트들 조회 (클러스터링 기반)
+/**
+ * ✅ 해당 키워드 기반 클러스터 노트 조회
+ */
 export async function fetchNotesByKeywordCluster(keywordId: number): Promise<Note[]> {
-  const res = await fetch(`/api/keywords/${keywordId}/clusters/notes`);
-  if (!res.ok) throw new Error("키워드 노트 조회 실패");
-  return res.json();
+  const res = await api.get(`/keywords/${keywordId}/clusters/notes`);
+  return res.data;
 }
 
-// ✅ 해당 키워드 기반 스크랩한 기사들 조회
+/**
+ * ✅ 해당 키워드 기반 클러스터 기사 조회
+ */
 export async function fetchArticlesByKeywordCluster(keywordId: number): Promise<Article[]> {
-  const res = await fetch(`/api/keywords/${keywordId}/clusters/articles`);
-  if (!res.ok) throw new Error("키워드 기사 조회 실패");
-  return res.json();
+  const res = await api.get(`/keywords/${keywordId}/clusters/articles`);
+  return res.data;
+}
+
+// 키워드 ID로 키워드 이름 가져오기
+export async function fetchKeywordName(keywordId: number): Promise<{ id: number; name: string }> {
+  const res = await fetch(`/api/keywords/${keywordId}`);
+  if (!res.ok) throw new Error("키워드 이름 불러오기 실패");
+  return res.json(); // { id, name }
 }

--- a/frontend/src/services/note.ts
+++ b/frontend/src/services/note.ts
@@ -1,26 +1,35 @@
+// ✅ src/services/note.ts
 import api from "./api";
-import type {Note} from "@/types/note";
-
+import type { Note } from "@/types/note";
+import type { Article } from "@/types/article";
 export async function getNotesByPage(page: number, size: number): Promise<{
   notes: Note[];
   totalPages: number;
 }> {
-  const res = await fetch(`/api/notes?page=${page}&size=${size}`);
-  return res.json();
+  const res = await api.get("/users/notes", {
+    params: { page, size },
+  });
+  return res.data;
 }
 
 export async function createNote(data: { title: string; content: string }) {
   const res = await api.post("/users/notes", data);
   return res.data;
 }
+
 export async function updateNote(id: number, data: { title: string; content: string }) {
   const res = await api.put(`/users/notes/${id}`, data);
   return res.data;
 }
+
 export async function getNotesByKeyword(keyword: string, page: number, size: number) {
-  const res = await fetch(`/api/notes?keyword=${encodeURIComponent(keyword)}&page=${page}&size=${size}`);
-  if (!res.ok) {
-    throw new Error("노트 불러오기 실패");
-  }
-  return res.json(); // { notes, totalPages } 형태 기대
+  const res = await api.get("/users/notes", {
+    params: { keyword, page, size },
+  });
+  return res.data; // { notes, totalPages }
+}
+
+export async function getArticlesByNoteId(noteId: number): Promise<Article[]> {
+  const res = await api.get(`/users/notes/${noteId}/articles`);
+  return res.data; // [{ id, title, link, ... }]
 }

--- a/frontend/src/services/scrap.ts
+++ b/frontend/src/services/scrap.ts
@@ -1,16 +1,12 @@
-// src/services/scrap.ts
+// ✅ src/services/scrap.ts
+import api from "./api";
 import type { ScrappedArticle } from "@/types/scrap";
 
-/**
- * 스크랩된 기사 전체 조회 또는 키워드 검색 (최신순)
- */
 export async function getScrappedArticles({
-  userId,
   keyword = "",
   page,
   size,
 }: {
-  userId: number;
   keyword?: string;
   page: number;
   size: number;
@@ -18,41 +14,15 @@ export async function getScrappedArticles({
   articles: ScrappedArticle[];
   totalPages: number;
 }> {
-  const params = new URLSearchParams({
-    userId: String(userId),
-    page: String(page),
-    size: String(size),
+  const res = await api.get("/users/scraps", {
+    params: { keyword, page, size },
   });
+  return res.data;
+}  
 
-  if (keyword.trim()) {
-    params.append("keyword", keyword);
-  }
-
-  const res = await fetch(`/api/scrap?${params.toString()}`);
-
-  if (!res.ok) {
-    throw new Error("스크랩된 기사 불러오기 실패");
-  }
-
-  return res.json(); // { articles, totalPages }
-}
-
-export async function getScrappedArticlesByKeyword(
-  userId: number,
-  keyword: string,
-  page: number,
-  size: number
-): Promise<{
-  articles: ScrappedArticle[];
-  totalPages: number;
-}> {
-  const res = await fetch(
-    `/api/scrap?userId=${userId}&keyword=${encodeURIComponent(keyword)}&page=${page}&size=${size}`
-  );
-
-  if (!res.ok) {
-    throw new Error("스크랩된 기사 불러오기 실패");
-  }
-
-  return res.json(); // { articles, totalPages }
+export async function getScrappedArticlesByKeyword(keyword: string, page: number, size: number) {
+  const res = await api.get("/users/scraps", {
+    params: { keyword, page, size },
+  });
+  return res.data;
 }

--- a/frontend/src/types/cluster.ts
+++ b/frontend/src/types/cluster.ts
@@ -8,6 +8,6 @@ export type Cluster = {
 
 export type PCluster = {
   id: number;
-  label: string;
+  label: number;
   keywords: Keyword[];
 };


### PR DESCRIPTION
Pull Request: 로그인 시스템 + 지식맵 & 키워드 기능 구현

📌 개요

로그인 인증 시스템과 사용자 기반 지식맵 시각화, 키워드 클러스터 탐색 기능을 통합하여 구현했습니다. 해당 PR은 다음 기능들을 포함합니다.

✅ 주요 기능 구현 사항

1. 🔐 사용자 인증 시스템 (JWT 기반)

로그인/회원가입 폼 구현

Login.tsx, SignupPage.tsx에 UI 및 유효성 검증 포함

JWT 발급 및 저장

로그인 성공 시 access_token을 localStorage에 저장

인증된 요청에 헤더 자동 삽입 (api.ts에 인터셉터 설정)

헤더 내 상태 표시 및 로그아웃 버튼 구현

로그인 여부에 따라 Header 우측에 사용자 정보 또는 로그인 버튼 표시

2. 🧠 지식맵 시각화 (D3 기반 키워드 그래프)

/dashboard 또는 /keyword-graph-preview에서 확인 가능

사용자 클러스터 데이터를 D3 force layout을 통해 시각화

클러스터별 키워드 연결 및 색상 구분 처리

키워드 클릭 시 /keywords/{id} 디테일 페이지로 이동 가능

3. 🧷 키워드 디테일 페이지 (/keywords/:keywordId)

해당 키워드를 포함한 노트 및 기사 데이터를 분리된 컬럼으로 출력

스크랩된 기사 없을 시 안내 메시지 출력

페이지네이션 적용 (PaginationComponent) → 노트, 기사 각각 독립적으로 페이징 가능

상단에 선택된 키워드 태그 시각화 추가

🛠 테스트 방법

로그인

/login → 로그인 후 Dashboard 자동 이동

지식맵 시각화 확인

/dashboard 또는 /keyword-graph-preview

키워드 디테일 이동 확인

그래프에서 키워드 클릭 → /keywords/:id로 이동

📁 관련 파일 구조