### PR TITLE
fix:헤더추가&링크색깔

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,13 +3,21 @@ import TodayIssuePreview from "@/components/TodayIssuePreview";
 import WeeklyIssuePreview from "@/components/WeeklyIssuePreview";
 // import { KeywordGraph } from "@/components/KeywordGraph";
 import Logo from "@/components/ui/logo";
+import Header from "@/components/Header";
 
 export default function HomePage() {
   return (
+
     <div className="min-h-screen px-10 py-8">
-      <div className="absolute top-2 left-2">
-        <Logo />
-      </div>
+      <header className="relative bg-sky-400 h-20 flex items-center px-6">
+        <div className="absolute left-6 top-1/2 transform -translate-y-1/2">
+          <Logo />
+        </div>
+        <h1 className="text-white text-xl font-bold mx-auto"></h1>
+        <div className="px-2 py -1">
+          <Header />
+        </div>
+      </header>
 
       <div className="flex justify-center mb-10">
         <TodayIssuePreview />

--- a/frontend/src/pages/TodayIssuePage.tsx
+++ b/frontend/src/pages/TodayIssuePage.tsx
@@ -101,7 +101,9 @@ export default function TodayIssuePage() {
                       href={article.link}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-blue-600 hover:underline"
+                      style={{ color: '#000000', textDecoration: 'none' /* hover 효과는 아래 예시 참고 */ }}
+                      onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
+                      onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
                     >
                       {article.title}
                     </a>

--- a/frontend/src/pages/trend/TrendLayout.tsx
+++ b/frontend/src/pages/trend/TrendLayout.tsx
@@ -1,18 +1,31 @@
 // src/pages/Trend/TrendLayout.tsx
 import { Outlet } from 'react-router-dom';
-import Logo from '@/components/ui/logo'; // className 없이 사용
+import Logo from '@/components/ui/logo';
 import TrendTab from '@/components/TrendTab';
+import Header from '@/components/Header';
 
 export default function TrendLayout() {
   return (
     <div className="p-6">
-      {/* 상단 Logo 좌상단 정렬 */}
-      <div className="mb-4">
-        <Logo />
-      </div>
+      <header className="bg-sky-400 h-20 px-6 flex items-center">
+        {/* 좌측: 로고 */}
+        <div className="flex-none">
+          <Logo />
+        </div>
 
-      {/* 제목과 탭 */}
-      <h1 className="text-2xl font-bold mb-4 text-blue-600">뉴스 트렌드</h1>
+        {/* 중앙: 타이틀 */}
+        <div className="flex-1 text-center">
+          <h1 className="text-white text-xl font-bold inline-block">
+            뉴스 트렌드
+          </h1>
+        </div>
+
+        {/* 우측: 헤더 */}
+        <div className="flex-none">
+          <Header />
+        </div>
+      </header>
+
       <TrendTab />
 
       {/* 탭 콘텐츠 영역 */}


### PR DESCRIPTION
- TodayIssuePage.tsx
    - tailwind 문법에서 이부분만 css문법(`<a>` 태그에 inline style)으로 대체
- HomePage.tsx
    - 오늘의 이슈, 노트페이지랑 같은 방식으로 로고, 헤더 뜨도록 변경
    - Header 컴포넌트를 import하고, `<header>` 안에 Logo와 함께 배치
- TrendLayout.tsx
    - Header 컴포넌트를 import하고, `<header>` 안에 Logo와 함께 배치
    - 다른 페이지랑 같은 방식으로 맞추려니까 TrendTab에서 <NavLink>클릭 시 로고가 대신 클릭되는 문제가 발생해 absolute 레이아웃 걷어내고 flex컨테이너 적용함