### PR TITLE
지식맵 구현 및 로그인/스크랩 캐시 동기화 개선

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@tailwindcss/postcss": "^4.1.8",
+        "@types/axios": "^0.9.36",
         "@types/d3": "^7.4.3",
         "@types/node": "^22.15.21",
         "@types/react": "^19.1.2",
@@ -1992,6 +1993,13 @@
       "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
       "dev": true
     },
+    "node_modules/@types/axios": {
+      "version": "0.9.36",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
+      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2736,6 +2744,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@tailwindcss/postcss": "^4.1.8",
+    "@types/axios": "^0.9.36",
     "@types/d3": "^7.4.3",
     "@types/node": "^22.15.21",
     "@types/react": "^19.1.2",

--- a/frontend/src/components/KeywordGraph.tsx
+++ b/frontend/src/components/KeywordGraph.tsx
@@ -1,15 +1,11 @@
-// 📄 src/components/KeywordGraph.tsx
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import * as d3 from "d3";
-import type { PCluster } from "@/types/cluster";
-import type { D3DragEvent } from "d3";
 
 type Node = {
   id: number;
   name: string;
-  clusterId: number;
-  count?: number; // ✅ count 추가
+  count: number;
   x?: number;
   y?: number;
   vx?: number;
@@ -21,87 +17,66 @@ type Node = {
 type Edge = {
   source: number | Node;
   target: number | Node;
+  weight?: number;
 };
 
 type Props = {
-  clusters: PCluster[];
+  nodes: Node[];
+  edges: Edge[];
 };
 
-export function KeywordGraph({ clusters }: Props) {
+export function KeywordGraph({ nodes, edges }: Props) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!svgRef.current) return;
 
-    const width = 600;
+    const width = 900;
     const height = 400;
 
-    const nodes: Node[] = clusters.flatMap((cluster) =>
-      cluster.keywords.map((k) => ({
-        id: k.id,
-        name: k.name,
-        clusterId: cluster.id,
-        count: k.count || 1, // ✅ count가 없으면 기본값 1
-      }))
-    );
-
-    const edges: Edge[] = clusters.flatMap((cluster) => {
-      const keywords = cluster.keywords;
-      const links: Edge[] = [];
-      for (let i = 0; i < keywords.length; i++) {
-        for (let j = i + 1; j < keywords.length; j++) {
-          links.push({ source: keywords[i].id, target: keywords[j].id });
-        }
-      }
-      return links;
-    });
-
     const svg = d3.select(svgRef.current);
-    svg.selectAll("*").remove();
+    svg.selectAll("*").remove(); // 초기화
+
+    const colorScale = d3
+      .scaleLinear<string>()
+      .domain([0, 0.5, 1])
+      .range(["#d0d0ff", "#8888ff", "#0000ff"]);
 
     const simulation = d3
       .forceSimulation<Node>(nodes)
-      .force("link", d3.forceLink<Node, Edge>(edges).id((d) => d.id).distance(80))
-      .force("charge", d3.forceManyBody().strength(-200))
-      .force("center", d3.forceCenter(width / 2, height / 2));
+      .force(
+        "link",
+        d3
+          .forceLink<Node, Edge>(edges)
+          .id((d) => d.id)
+          .distance(180)
+      )
+      .force("charge", d3.forceManyBody().strength(-50))
+      .force("center", d3.forceCenter(width / 2, height / 2))
+      .force("x", d3.forceX<Node>(width / 2).strength(0.01))
+      .force("y", d3.forceY<Node>(height / 2).strength(0.03))
+      .force(
+        "collision",
+        d3
+          .forceCollide<Node>()
+          .radius((d) => {
+            const fontSize = 10 + Math.min(d.count, 20);
+            return fontSize + d.name.length * 3;
+          })
+      );
 
     const link = svg
       .append("g")
-      .attr("stroke", "#aaa")
+      .attr("stroke-opacity", 0.6)
       .selectAll("line")
       .data(edges)
       .join("line")
-      .attr("stroke-width", 1.5);
-
-    const node = svg
-      .append("g")
-      .selectAll<SVGCircleElement, Node>("circle")
-      .data(nodes)
-      .join("circle")
-      .attr("r", (d) => 8 + Math.min(d.count || 1, 20)) // ✅ count에 따라 반영됨
-      .attr("fill", (d) => d3.schemeCategory10[d.clusterId % 10])
-      .style("cursor", "pointer")
-      .on("click", (event, d) => {
-        navigate(`/keywords/${d.id}`);
-      })
-      .call(
-        d3
-          .drag<SVGCircleElement, Node>()
-          .on("start", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-            if (!event.active) simulation.alphaTarget(0.3).restart();
-            d.fx = d.x;
-            d.fy = d.y;
-          })
-          .on("drag", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-            d.fx = event.x;
-            d.fy = event.y;
-          })
-          .on("end", (event: D3DragEvent<SVGCircleElement, Node, Node>, d) => {
-            if (!event.active) simulation.alphaTarget(0);
-            d.fx = null;
-            d.fy = null;
-          })
+      .attr("stroke", (d) =>
+        colorScale(d.weight !== undefined ? d.weight : 0)
+      )
+      .attr("stroke-width", (d) =>
+        d3.scaleLinear().domain([0, 1]).range([1, 4])(d.weight || 0)
       );
 
     const labels = svg
@@ -110,32 +85,95 @@ export function KeywordGraph({ clusters }: Props) {
       .data(nodes)
       .join("text")
       .text((d) => d.name)
-      .attr("font-size", 12)
+      .attr("font-size", (d) => `${10 + Math.min(d.count, 20)}px`)
       .attr("text-anchor", "middle")
-      .attr("dy", 4);
+      .attr("dy", 4)
+      .attr("fill", "black")
+      .style("cursor", "pointer")
+      .on("click", (_, d) => navigate(`/keywords/${d.id}`));
 
+    (labels as d3.Selection<SVGTextElement, Node, any, any>).call(
+      d3
+        .drag<SVGTextElement, Node>()
+        .on("start", (event, d) => {
+          if (!event.active) simulation.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        })
+        .on("drag", (event, d) => {
+          d.fx = event.x;
+          d.fy = event.y;
+        })
+        .on("end", (event, d) => {
+          if (!event.active) simulation.alphaTarget(0);
+          d.fx = null;
+          d.fy = null;
+        })
+    );
+
+    // ✅ tick 함수에서 간선 길이 보정
     simulation.on("tick", () => {
       link
-        .attr("x1", (d) => (d.source as Node).x!)
-        .attr("y1", (d) => (d.source as Node).y!)
-        .attr("x2", (d) => (d.target as Node).x!)
-        .attr("y2", (d) => (d.target as Node).y!);
+        .attr("x1", (d) => {
+          const src = d.source as Node;
+          const tgt = d.target as Node;
+          return adjustLinePosition(src, tgt).x1;
+        })
+        .attr("y1", (d) => {
+          const src = d.source as Node;
+          const tgt = d.target as Node;
+          return adjustLinePosition(src, tgt).y1;
+        })
+        .attr("x2", (d) => {
+          const src = d.source as Node;
+          const tgt = d.target as Node;
+          return adjustLinePosition(src, tgt).x2;
+        })
+        .attr("y2", (d) => {
+          const src = d.source as Node;
+          const tgt = d.target as Node;
+          return adjustLinePosition(src, tgt).y2;
+        });
 
-      node.attr("cx", (d) => d.x!).attr("cy", (d) => d.y!);
       labels.attr("x", (d) => d.x!).attr("y", (d) => d.y!);
     });
 
-    return () => {
-      simulation.stop();
-    };
-  }, [clusters, navigate]);
+    return () => simulation.stop();
+
+    // ✅ 라인 끝 좌표를 조정하여 텍스트 외곽에서 연결되도록 함
+    function adjustLinePosition(src: Node, tgt: Node) {
+      const dx = tgt.x! - src.x!;
+      const dy = tgt.y! - src.y!;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist === 0) return { x1: src.x!, y1: src.y!, x2: tgt.x!, y2: tgt.y! };
+
+      // 출발점과 도착점에서 각각 padding 만큼 밀기
+      const offsetSrc = getNodeRadius(src);
+      const offsetTgt = getNodeRadius(tgt);
+
+      const ratioSrc = offsetSrc / dist;
+      const ratioTgt = offsetTgt / dist;
+
+      return {
+        x1: src.x! + dx * ratioSrc,
+        y1: src.y! + dy * ratioSrc,
+        x2: tgt.x! - dx * ratioTgt,
+        y2: tgt.y! - dy * ratioTgt,
+      };
+    }
+
+    function getNodeRadius(d: Node) {
+      const fontSize = 10 + Math.min(d.count, 20);
+      return fontSize + d.name.length * 5;
+    }
+  }, [nodes, edges, navigate]);
 
   return (
-  <svg
-    ref={svgRef}
-    viewBox="0 0 600 400"
-    preserveAspectRatio="xMidYMid meet"
-    className="w-full h-auto mx-auto my-4"
-  />
-);
+    <svg
+      ref={svgRef}
+      viewBox="0 0 900 400"
+      preserveAspectRatio="xMidYMid meet"
+      className="w-full h-auto mx-auto my-4"
+    />
+  );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,7 +8,6 @@ import { getScrappedArticles } from "@/services/scrap";
 import { fetchLatestKnowledgeMap } from "@/services/knowledgeMap";
 import type { Note } from "@/types/note";
 import type { ScrappedArticle } from "@/types/scrap";
-import type { KnowledgeMap } from "@/types/knowledgeMap";
 import { KeywordGraph } from "@/components/KeywordGraph";
 import { Button } from "@/components/ui/button";
 import Header from "@/components/Header";
@@ -18,32 +17,18 @@ export default function DashboardPage() {
 
   const [notes, setNotes] = useState<Note[]>([]);
   const [scraps, setScraps] = useState<ScrappedArticle[]>([]);
-  const [map, setMap] = useState<KnowledgeMap | null>(null);
+  const [nodes, setNodes] = useState([]);
+  const [edges, setEdges] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     Promise.all([
       getNotesByPage(1, 3).then((res) => setNotes(res.notes)),
       getScrappedArticles({ page: 1, size: 5 }).then((res) => setScraps(res.articles)),
-      fetchLatestKnowledgeMap().then((res) => {
-        if (res && 'keywords' in res) {
-          setMap({
-            id: res.id,
-            clusters: [
-              {
-                id: 0,
-                label: 1,
-                keywords: (res.keywords as Array<{ id: number; name: string }>).map((k) => ({
-                  ...k,
-                  count: 1,
-                  clusterId: 0,
-                })),
-              },
-            ],
-          });
-        } else {
-          setMap(res);
-        }
+      fetchLatestKnowledgeMap().then((res: any) => {
+        console.log("📦 지식맵 응답:", res); 
+        setNodes(res.nodes || []);
+        setEdges(res.edges || []);
       }),
     ]).finally(() => setIsLoading(false));
   }, []);
@@ -54,10 +39,19 @@ export default function DashboardPage() {
 
   return (
     
-    <div >
-      <div className="mb-5">
-            <Header />
-      </div>
+    <div className="min-h-screen flex flex-col justify-start">
+          <header className="h-25 bg-blue-500 text-white px-6 flex items-center justify-between mb-10">
+            <div className="flex items-center">
+              <Logo />
+            </div>
+            <h1 className="text-white text-4xl font-bmjua">
+              MY PAGE
+            </h1>
+            <div className="px-2 py -1">
+              <Header />
+            </div>
+          </header>
+
       {/* ✅ 본문 (세로 정렬) */}
       <main className="px-6 flex flex-col items-center gap-10">
         {/* ✅ 지식맵 */}
@@ -66,8 +60,8 @@ export default function DashboardPage() {
             <h2 className="font-bold text-lg">MY KNOWLEDGE-MAP</h2>
           </div>
           <div className="bg-gray-50 border rounded px-4 py-3">
-            {map?.clusters?.length && map.clusters.length > 0 ? (
-              <KeywordGraph clusters={map.clusters} />
+            {nodes.length > 0 ? (
+              <KeywordGraph nodes={nodes} edges={edges} />
             ) : (
               <p className="text-sm text-gray-500">지식맵이 없습니다.</p>
             )}

--- a/frontend/src/pages/KeywordDetailPage.tsx
+++ b/frontend/src/pages/KeywordDetailPage.tsx
@@ -23,10 +23,14 @@ export default function KeywordDetailPage() {
   useEffect(() => {
     if (!keywordId) return;
 
-    fetchKeywordName(Number(keywordId)).then((res: { name: string }) => setKeywordName(res.name));
+    fetchKeywordName(Number(keywordId)).then((res) => setKeywordName((res as { name: string }).name));
 
-    fetchArticlesByKeywordCluster(keywordId).then((res) => {
-      setArticles(res);
+    fetchArticlesByKeywordCluster(Number(keywordId)).then((res) => {
+      if (Array.isArray(res)) {
+        setArticles(res);
+      } else if (res && typeof res === "object" && "articles" in res) {
+        setArticles((res as { articles: Article[] }).articles);
+      }
       setNoteTotalPages(1);
       setNotes([]);
       // If you have totalPages info, update this accordingly; otherwise, remove or set to 1
@@ -72,15 +76,20 @@ export default function KeywordDetailPage() {
           </div>
         </section>
 
-        {/* SCAP 영역 */}
+        {/* SCRAP 영역 */}
         <section className="flex-1">
-          <h2 className="text-2xl font-bold mb-6">SCAP</h2>
+          <h2 className="text-2xl font-bold mb-6">SCRAP</h2>
           {articles.length > 0 ? (
-            <ul className="space-y-3 text-sm text-blue-600">
+            <ul className="space-y-3 text-sm text-black">
               {articles.map((article) => (
-                <li key={article.id}>
-                  <a href={article.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                    {article.link}
+                <li key={article.article_id}>
+                  <a
+                    href={article.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:underline text-black"
+                  >
+                    {article.title}
                   </a>
                 </li>
               ))}

--- a/frontend/src/pages/KeywordMapPage.tsx
+++ b/frontend/src/pages/KeywordMapPage.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { fetchLatestKnowledgeMap } from "@/services/knowledgeMap";
+import { KeywordGraph } from "@/components/KeywordGraph";
+
+export default function KeywordMapPage() {
+  const [nodes, setNodes] = useState<any[]>([]);
+  const [edges, setEdges] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetchLatestKnowledgeMap()
+      .then((res) => {
+        const data = res as { nodes?: any[]; edges?: any[] };
+        setNodes(data.nodes || []);
+        setEdges(data.edges || []);
+      })
+      .catch((err) => console.error("지식맵 그래프 로딩 실패", err))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) return <p className="p-4 text-center">로딩 중...</p>;
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-4">📚 나의 최신 지식맵</h2>
+      {nodes.length > 0 ? (
+        <KeywordGraph nodes={nodes} edges={edges} />
+      ) : (
+        <p className="text-sm text-gray-500">지식맵이 없습니다.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/knowledgeMap.ts
+++ b/frontend/src/types/knowledgeMap.ts
@@ -1,5 +1,18 @@
-import type { Cluster} from '@/types/cluster';
+export type KeywordNode = {
+  id: number;
+  name: string;
+  count: number;
+};
+
+export type KeywordEdge = {
+  source: number;
+  target: number;
+  weight: number;
+};
+
 export type KnowledgeMap = {
   id: number;
-  clusters: Cluster[];
+  created_at: string;
+  nodes: KeywordNode[];
+  edges: KeywordEdge[];
 };

--- a/project/api/create_app.py
+++ b/project/api/create_app.py
@@ -127,7 +127,7 @@ def create_app():
     app.include_router(scrap.router,    prefix="/users",    tags=["scrap"])
     app.include_router(trend.router,    prefix="/trends",    tags=["trend"])
     app.include_router(notes.router, prefix="/users", tags=["notes"])
-    app.include_router(knowledge_map.router, prefix="/users", tags=["knowledge-map"])
+    app.include_router(knowledge_map.router, prefix="/users", tags=["knowledge_map"])
 
 
     return app

--- a/project/api/routes/knowledge_map.py
+++ b/project/api/routes/knowledge_map.py
@@ -1,266 +1,84 @@
 # api/routes/knowledge_map.py
-
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
-from datetime import datetime
-from models.user import User, KnowledgeMap
-from models.note import Note, NoteArticle
-from models.scrap import PCluster, PClusterKeyword, PClusterArticle
-from models.article import Article
-from api.utils.auth import get_current_user
-from database.deps import get_db
-from api.schemas.knowledge_map import KnowledgeMapCreateRequest
+from sklearn.metrics.pairwise import cosine_similarity
 
+from models.article import Article
+from models.user import User
+from models.scrap import PKeyword, PKeywordArticle
+from api.utils.auth import get_current_user
+from api.utils.cache import get_cache
+from tasks.user_scrap_pipeline import build_knowledge_map
+from database.deps import get_db
+from clustering.embedder import make_embeddings
+from clustering.keyword_extractor import get_top_keywords
+from api.schemas.knowledge_map import KnowledgeMapOut, Message
+from api.schemas.cluster import ArticleOut
+from tasks.user_scrap_pipeline import build_knowledge_map
+from redis import Redis
 router = APIRouter()
 
-@router.post("/knowledge-maps")
-def create_knowledge_maps(
-    request_data: KnowledgeMapCreateRequest,
+@router.post("/knowledge_map/update", response_model=Message)
+def update_knowledge_map(current_user: User = Depends(get_current_user)):
+    result = build_knowledge_map(current_user.id)
+    if result == "SUCCESS":
+        return {"message": "Knowledge map updated and cached in Redis"}
+    else:
+        raise HTTPException(status_code=500, detail="Knowledge map update failed")
+
+# GET: 캐시된 지식맵 조회 or Celery 생성 요청
+@router.get("/knowledge_map/graph", response_model=KnowledgeMapOut)
+def get_or_create_knowledge_map_graph(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    created_map_ids = []
+    redis_client = Redis(host="localhost", port=6379, db=0, decode_responses=True)
+   
+    cache_key = f"user:{current_user.id}:knowledge_map"
+    cached = get_cache(cache_key)
+    
+    if cached:
+        try:
+            # 검증된 모델로 감싸서 리턴
+            return KnowledgeMapOut(**cached)
+        except Exception as e:
+            print(f"[Cache parsing error] {e}")
+            redis_client.delete(cache_key)  # 캐시 삭제 (오류난 구조니까)
+            return JSONResponse(
+                status_code=500,
+                content={"message": "캐시된 지식맵 데이터에 오류가 있습니다."}
+            )
 
-    for cluster in request_data.result:
-        # 1. KnowledgeMap 생성
-        knowledge_map = KnowledgeMap(user_id=current_user.id)
-        db.add(knowledge_map)
-        db.commit()
-        db.refresh(knowledge_map)
-        created_map_ids.append(knowledge_map.id)
+    # 없으면 생성 요청
+    return JSONResponse(
+        status_code=202,
+        content={"message": "지식맵을 생성 중입니다. 잠시 후 다시 시도해주세요."}
+    )
 
-        # 2. PCluster 생성 (label 단위로)
-        pcluster = PCluster(
-            label=cluster.label,
-            knowledge_map_id=knowledge_map.id
-        )
-        db.add(pcluster)
-        db.commit()
-        db.refresh(pcluster)
-
-        # 3. 키워드 등록
-        for keyword in cluster.keywords:
-            db.add(PClusterKeyword(keyword=keyword, pcluster_id=pcluster.id))
-
-        # 4. 기사 연결
-        for article_id in cluster.articleIds:
-            article = db.query(Article).filter(Article.id == article_id).first()
-            if not article:
-                raise HTTPException(status_code=404, detail=f"Article {article_id} not found")
-            db.add(PClusterArticle(article_id=article_id, pcluster_id=pcluster.id))
-
-        db.commit()
-
-    return {
-        "isSuccess": True,
-        "code": "KNOWLEDGE_MAPS_CREATED",
-        "message": "지식맵이 성공적으로 생성되었습니다.",
-        "result": {
-            "knowledgeMapIds": created_map_ids
-        }
-    }
-
-
-@router.get("/knowledge_maps/graph")
-def get_latest_knowledge_map(
+@router.get("/keywords/{keyword_id}/articles", response_model=list[ArticleOut])
+def get_articles_by_keyword(
+    keyword_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ):
-    # 1. 가장 최근 지식맵 하나 가져오기
-    latest_map = (
-        db.query(KnowledgeMap)
-        .filter(KnowledgeMap.user_id == current_user.id)
-        .order_by(KnowledgeMap.created_at.desc())
-        .first()
-    )
-
-    if not latest_map:
-        raise HTTPException(status_code=404, detail="지식맵이 존재하지 않습니다.")
-
-    nodes = []
-    edges = []
-
-    # 2. 지식맵에 속한 클러스터들 가져오기
-    clusters = db.query(PCluster).filter(PCluster.knowledge_map_id == latest_map.id).all()
-
-    for cluster in clusters:
-        cluster_id = f"cl-{cluster.id}"
-        nodes.append({"id": cluster_id, "label": cluster.label, "type": "cluster"})
-
-        # 2-1. 키워드 노드 + 엣지
-        keywords = db.query(PClusterKeyword).filter(PClusterKeyword.pcluster_id == cluster.id).all()
-        for kw in keywords:
-            keyword_id = f"kw-{kw.keyword}"
-            nodes.append({"id": keyword_id, "label": kw.keyword, "type": "keyword"})
-            edges.append({"source": cluster_id, "target": keyword_id})
-
-        # 2-2. 기사 노드 + 엣지
-        article_links = db.query(PClusterArticle).filter(PClusterArticle.pcluster_id == cluster.id).all()
-        article_ids = [a.article_id for a in article_links]
-        articles = db.query(Article).filter(Article.id.in_(article_ids)).all()
-
-        for article in articles:
-            article_id = f"ar-{article.id}"
-            nodes.append({"id": article_id, "label": article.title, "type": "article"})
-            edges.append({"source": cluster_id, "target": article_id})
-
-    return {
-        "isSuccess": True,
-        "code": "LATEST_KNOWLEDGE_MAP",
-        "message": "최신 지식맵을 불러왔습니다.",
-        "result": {
-            "nodes": nodes,
-            "edges": edges
-        }
-    }
-
-@router.get("/keywords/{keyword_id}/clusters/notes")
-def get_notes_by_keyword(
-    keyword_id: str,
-    page: int = Query(1, ge=1),
-    size: int = Query(10, ge=1),
-    db: Session = Depends(get_db)
-):
-    offset = (page - 1) * size
-
-    # 1. keyword_id로 클러스터 id 찾기
-    cluster_ids = (
-        db.query(PClusterKeyword.pcluster_id)
-        .filter(PClusterKeyword.keyword == keyword_id)
-        .distinct()
-        .all()
-    )
-    cluster_ids = [cid for (cid,) in cluster_ids]
-
-    if not cluster_ids:
-        raise HTTPException(status_code=404, detail="해당 키워드를 가진 클러스터가 없습니다.")
-
-    # 2. 해당 클러스터들이 연결한 기사 ID 수집
-    article_ids = (
-        db.query(PClusterArticle.article_id)
-        .filter(PClusterArticle.pcluster_id.in_(cluster_ids))
-        .distinct()
-        .all()
-    )
-    article_ids = [aid for (aid,) in article_ids]
-
-    if not article_ids:
-        return {
-            "page": page,
-            "size": size,
-            "keyword": keyword_id,
-            "notes": []
-        }
-
-    # 3. 해당 기사들과 연결된 노트 ID 수집
-    note_ids = (
-        db.query(NoteArticle.note_id)
-        .filter(NoteArticle.article_id.in_(article_ids))
-        .distinct()
-        .all()
-    )
-    note_ids = [nid for (nid,) in note_ids]
-
-    if not note_ids:
-        return {
-            "page": page,
-            "size": size,
-            "keyword": keyword_id,
-            "notes": []
-        }
-
-    # 4. 노트 정보 + 연결된 기사 ID 함께 조회
-    notes = (
-        db.query(Note)
-        .filter(Note.id.in_(note_ids), Note.state == True)
-        .order_by(Note.created_at.desc())
-        .offset(offset)
-        .limit(size)
+    # 1. 유저가 스크랩한 기사들 중에서
+    # 2. keyword_id와 연결된 PKeywordArticle이 있는 것만 필터링
+    results = (
+        db.query(Article)
+        .join(PKeywordArticle, PKeywordArticle.article_id == Article.id)
+        .filter(PKeywordArticle.pkeyword_id == keyword_id)
         .all()
     )
 
-    result_notes = []
-    for note in notes:
-        related_articles = db.query(NoteArticle.article_id).filter(NoteArticle.note_id == note.id).all()
-        related_article_ids = [aid for (aid,) in related_articles]
-
-        result_notes.append({
-            "note_id": note.id,
-            "title": note.title,
-            "text": note.text,
-            "related_article_ids": related_article_ids,
-            "created_at": note.created_at
-        })
-
-    return {
-        "page": page,
-        "size": size,
-        "keyword": keyword_id,
-        "notes": result_notes
-    }
-
-
-@router.get("/keywords/{keyword}/clusters/articles")
-def get_clusters_by_keyword(
-    keyword: str,
-    page: int = Query(1, ge=1),
-    size: int = Query(10, ge=1),
-    db: Session = Depends(get_db)
-):
-    offset = (page - 1) * size
-
-    # 1. 해당 키워드를 가진 클러스터 id들 조회
-    cluster_ids = (
-        db.query(PClusterKeyword.pcluster_id)
-        .filter(PClusterKeyword.keyword == keyword)
-        .distinct()
-        .all()
-    )
-    cluster_ids = [cid for (cid,) in cluster_ids]
-
-    if not cluster_ids:
-        return {
-            "page": page,
-            "size": size,
-            "keyword": keyword,
-            "clusters": []
-        }
-
-    # 2. 페이징된 클러스터 조회
-    clusters = (
-        db.query(PCluster)
-        .filter(PCluster.id.in_(cluster_ids))
-        .order_by(PCluster.id.desc())
-        .offset(offset)
-        .limit(size)
-        .all()
-    )
-
-    # 3. 각 클러스터마다 연결된 기사들 조회
-    result_clusters = []
-    for cluster in clusters:
-        article_ids = (
-            db.query(PClusterArticle.article_id)
-            .filter(PClusterArticle.pcluster_id == cluster.id)
-            .distinct()
-            .all()
+    # ✅ FastAPI가 기대하는 스키마 형태에 맞게 매핑
+    return [
+        ArticleOut(
+            article_id=article.id,  # ✅ 여기서 명시적으로 지정
+            title=article.title,
+            summary=article.summary,
+            link=article.link,
+            published=article.published,
         )
-        article_ids = [aid for (aid,) in article_ids]
-
-        articles = db.query(Article).filter(Article.id.in_(article_ids)).all()
-
-        result_clusters.append({
-            "cluster_id": cluster.id,
-            "label": cluster.label,
-            "articles": [
-                {"id": a.id, "title": a.title, "link": a.link}
-                for a in articles
-            ]
-        })
-
-    return {
-        "page": page,
-        "size": size,
-        "keyword": keyword,
-        "clusters": result_clusters
-    }
+        for article in results
+    ]

--- a/project/api/routes/user.py
+++ b/project/api/routes/user.py
@@ -90,7 +90,8 @@ def login(user: UserLogin, response: Response, db: Session = Depends(get_db)):
 
     return {
         "message": "로그인에 성공했습니다.",
-        "access_token": access_token
+        "access_token": access_token,
+        "user_id": db_user.id   
     }
 
 # 로그아웃

--- a/project/api/schemas/knowledge_map.py
+++ b/project/api/schemas/knowledge_map.py
@@ -1,10 +1,25 @@
+#schemas/knowledge_map.py
 from pydantic import BaseModel
 from typing import List
 
-class ClusterInput(BaseModel):
-    label: str
-    keywords: List[str]
-    articleIds: List[int]
+class KeywordNode(BaseModel):
+    id: int
+    name: str
+    count: int
 
-class KnowledgeMapCreateRequest(BaseModel):
-    result: List[ClusterInput]
+    class Config:
+        orm_mode = True
+
+class KeywordEdge(BaseModel):
+    source: int
+    target: int
+    weight: float
+
+class KnowledgeMapOut(BaseModel):
+    id: int
+    created_at: str
+    nodes: List[KeywordNode]
+    edges: List[KeywordEdge]
+
+class Message(BaseModel):
+    message: str

--- a/project/api/utils/cache.py
+++ b/project/api/utils/cache.py
@@ -1,0 +1,11 @@
+import redis
+import json
+
+redis_client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+
+def get_cache(key: str):
+    val = redis_client.get(key)
+    return json.loads(val) if val else None
+
+def set_cache(key: str, value, ttl: int = 3600):
+    redis_client.setex(key, ttl, json.dumps(value))

--- a/project/clustering/keyword_extractor.py
+++ b/project/clustering/keyword_extractor.py
@@ -3,6 +3,7 @@
 from typing import List, Dict
 from sqlalchemy.orm import Session
 from sklearn.feature_extraction.text import TfidfVectorizer
+from models.scrap import PKeyword
 from clustering.embedder import STOPWORDS_KO
 from models.article import Keyword, ClusterKeyword
 from collections import Counter
@@ -120,3 +121,39 @@ def generate_candidates(
     # 4) 중복 제거 후 반환
     #    (순서는 빈도순 유지하려면 추가 로직 필요)
     return list(dict.fromkeys(candidates))
+
+def extract_keywords_per_article(documents: List[str], top_n: int = 3, max_features: int = 300) -> List[List[str]]:
+    """
+    여러 기사에 대해 각각의 top_n 키워드를 추출해서 리스트로 반환.
+    전체 문서를 기준으로 TF-IDF 모델을 학습한 후, 각 기사에 적용함.
+    """
+    vectorizer = TfidfVectorizer(
+        stop_words=list(STOPWORDS_KO),
+        max_features=max_features,
+        min_df=0.02
+    )
+    tfidf_matrix = vectorizer.fit_transform(documents)
+    feature_names = vectorizer.get_feature_names_out()
+
+    top_keywords_list = []
+    for i in range(tfidf_matrix.shape[0]):
+        tfidf_vector = tfidf_matrix[i].toarray().flatten()
+        top_indices = tfidf_vector.argsort()[::-1][:top_n]
+        top_terms = [feature_names[j] for j in top_indices if tfidf_vector[j] > 0]
+        top_keywords_list.append(top_terms if top_terms else ["no_keyword"])
+
+    return top_keywords_list
+
+# 각 키워드마다 점수 계산: 중요도 점수 = alpha * count + (1 - alpha) * 연결 수
+def get_top_keywords(pkeywords: List[PKeyword], alpha: float = 0.7, limit: int = 20) -> List[PKeyword]:
+    """
+    count (사용자 관심도)와 연결 수 (콘텐츠 연관도)를 조합하여 상위 키워드 선정
+    """
+    def score(pk: PKeyword):
+        count_score = pk.count
+        connection_score = len(pk.connections) if hasattr(pk, "connections") else 0
+        return alpha * count_score + (1 - alpha) * connection_score
+    
+    # 점수 기준 정렬 후 상위 limit개 선택
+    sorted_keywords = sorted(pkeywords, key=score, reverse=True)
+    return sorted_keywords[:limit]

--- a/project/models/__init__.py
+++ b/project/models/__init__.py
@@ -5,5 +5,5 @@
 from .user import User, KnowledgeMap
 from .article import Article, Cluster, ClusterKeyword
 from .note import Note, NoteArticle
-from .scrap import Scrap
+from .scrap import Scrap, PKeyword, PKeywordArticle
 from .base import Base

--- a/project/models/article.py
+++ b/project/models/article.py
@@ -71,7 +71,7 @@ class Keyword(Base):
 
     # 관계
     cluster_keyword = relationship("ClusterKeyword", back_populates="keyword")
-    pcluster_keyword = relationship("PClusterKeyword", back_populates="keyword")
+    #pcluster_keyword = relationship("PClusterKeyword", back_populates="keyword")
     # trend_keywords = relationship("TrendKeyword", back_populates="keyword")
     # today_keywords = relationship("TodayKeywordHourly", back_populates="keyword")
 

--- a/project/models/article.py
+++ b/project/models/article.py
@@ -25,7 +25,7 @@ class Article(Base):
     scrap = relationship("Scrap", back_populates="article")
     note_article = relationship("NoteArticle", back_populates="article")
     cluster_article = relationship("ClusterArticle", back_populates="article")
-    pcluster_article = relationship("PClusterArticle", back_populates="article")
+    pkeyword_articles = relationship("PKeywordArticle", back_populates="article")
 
 class Cluster(Base):
     __tablename__ = "cluster"

--- a/project/models/scrap.py
+++ b/project/models/scrap.py
@@ -2,7 +2,7 @@
 # 역할: 스크랩 관련 모델 정의
 # scrap, pcluster, pcluster_article, pcluster_keyword
 
-from sqlalchemy import Column, BigInteger, Integer, DateTime, Boolean, ForeignKey
+from sqlalchemy import Column, BigInteger, Integer, DateTime, Boolean, ForeignKey, String
 from datetime import datetime, timezone
 from models.base import Base
 from sqlalchemy.orm import relationship
@@ -21,37 +21,27 @@ class Scrap(Base):
     article = relationship("Article", back_populates="scrap")
     user = relationship("User", back_populates="scrap")
 
-class PCluster(Base):
-    __tablename__ = "pcluster"
+class PKeyword(Base):
+    __tablename__ = "pkeyword"
 
     id = Column(BigInteger, primary_key=True, index=True)
-    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
-    label = Column(Integer, nullable=False)
-    knowledge_map_id = Column(BigInteger, ForeignKey("knowledge_map.id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    count = Column(Integer, nullable=False, default=0)
+    knowledge_map_id = Column(BigInteger, ForeignKey("knowledge_map.id"), nullable=True)
+    user_id = Column(BigInteger, ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
 
     # 관계
-    knowledge_map = relationship("KnowledgeMap", back_populates="pcluster")
-    pcluster_article = relationship("PClusterArticle", back_populates="pcluster")
-    pcluster_keyword = relationship("PClusterKeyword", back_populates="pcluster")
+    knowledge_map = relationship("KnowledgeMap", back_populates="pkeywords")
+    user = relationship("User", back_populates="pkeywords")
+    pkeyword_articles = relationship("PKeywordArticle", back_populates="pkeyword")
 
-class PClusterArticle(Base):
-    __tablename__ = "pcluster_article"
+class PKeywordArticle(Base):
+    __tablename__ = "pkeyword_article"
 
     id = Column(BigInteger, primary_key=True, index=True)
-    pcluster_id = Column(BigInteger, ForeignKey("pcluster.id", ondelete="CASCADE"), nullable=False)
+    pkeyword_id = Column(BigInteger, ForeignKey("pkeyword.id", ondelete="CASCADE"), nullable=False)
     article_id = Column(BigInteger, ForeignKey("article.id", ondelete="CASCADE"), nullable=False)
 
     # 관계
-    pcluster = relationship("PCluster", back_populates="pcluster_article")
-    article = relationship("Article", back_populates="pcluster_article")
-
-class PClusterKeyword(Base):
-    __tablename__ = "pcluster_keyword"
-
-    id = Column(BigInteger, primary_key=True, index=True)
-    pcluster_id = Column(BigInteger, ForeignKey("pcluster.id", ondelete="CASCADE"), nullable=False)
-    keyword_id = Column(BigInteger, ForeignKey("keyword.id", ondelete="CASCADE"), nullable=False)
-
-    # 관계
-    pcluster = relationship("PCluster", back_populates="pcluster_keyword")
-    keyword = relationship("Keyword", back_populates="pcluster_keyword")
+    pkeyword = relationship("PKeyword", back_populates="pkeyword_articles")
+    article = relationship("Article", back_populates="pkeyword_articles")

--- a/project/models/user.py
+++ b/project/models/user.py
@@ -2,7 +2,7 @@
 # 역할: 사용자 관련 모델 정의
 # user, knowledge_map
 
-from sqlalchemy import Column, BigInteger, String, DateTime, ForeignKey
+from sqlalchemy import Column, BigInteger, String, DateTime, ForeignKey, Boolean
 from datetime import datetime, timezone
 from models.base import Base
 from sqlalchemy.orm import relationship
@@ -22,15 +22,16 @@ class User(Base):
     knowledge_maps = relationship("KnowledgeMap", back_populates="user")
     notes = relationship("Note", back_populates="user")
     scrap = relationship("Scrap", back_populates="user")
-
+    pkeywords = relationship("PKeyword", back_populates="user")
 
 class KnowledgeMap(Base):
     __tablename__ = "knowledge_map"
 
     id = Column(BigInteger, primary_key=True, index=True)
     created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
+    is_valid = Column(Boolean, default=True)
     user_id = Column(BigInteger, ForeignKey("user.id", ondelete="CASCADE"), nullable=False) 
     
     # 관계
     user = relationship("User", back_populates="knowledge_maps")
-    pcluster = relationship("PCluster", back_populates="knowledge_map")
+    pkeywords = relationship("PKeyword", back_populates="knowledge_map")


### PR DESCRIPTION
### 개요
1. 지식맵 생성
- 키워드 클릭 시 해당 키워드와 연관된 스크랩 기사를 확인할 수 있도록 백엔드와 프론트엔드 로직을 연동
- 지식맵 시각화
2. 클러스터 상세 페이지-로그인 오류 수정
- 로그인 시 계정 전환을 감지하고 이전 계정의 스크랩 캐시(localStorage)를 초기화
- 스크랩 상태를 서버 응답 기준으로 일원화하여 사용자 간 데이터 혼선을 방지

###  주요 변경사항
1. 지식맵
✅ 백엔드
- /keywords/{keyword_id}/articles GET API 구현
- 사용자가 스크랩한 기사 중 해당 키워드에 연결된 기사만 필터링하여 반환
- pkeyword_article 테이블 기반으로 필터링 수행
- FastAPI 응답 스키마에 맞게 article_id 필드 사용 유지 및 일관성 확보
✅ 프론트엔드
- 키워드 클릭 시 관련 기사 조회 페이지(/keywords/:id)로 이동하도록 D3 그래프에 클릭 이벤트 추가
- KeywordDetailPage에서 키워드 이름과 함께 스크랩 기사 목록 출력
- 제목을 검정색 텍스트로 표시
- 마우스 오버 시 밑줄 표시
- 클릭 시 원본 기사 링크로 이동
- D3.js 그래프 내 간선과 키워드 텍스트가 겹치지 않도록 여백 및 위치 조정
- forceLink().distance() 및 forceCollide() 개선
- 링크 선이 텍스트 테두리에 닿도록 조정
- 간선 색상은 weight 값에 따라 동적 색상 적용
2. 로그인
- AuthContext에 userId 추가 및 계정 전환 시 스크랩 캐시 초기화
- /login 응답에 user_id 포함
- 로그인 후 access_token과 user_id를 함께 context에 전달
- ClusterDetailPage.tsx에서 로컬 캐시 대신 서버 응답으로 스크랩 상태 표시

## 추가 사항
- 지식맵 생성에 redis 기반 캐싱 적용 -> redis 설치하고 서버 따로 돌려야함 (redis, 백엔드, 프론트엔드)
- 지식맵 더 예쁘게 만들면 좋겠지만...이건 어케 할지 모르겠음 클러스터 기반 생성이 아니라 색 지정 기준을 결정하기 애매함