### PR TITLE
뉴스트렌드 프론트 전반적으로 수정

### DIFF
--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -6,7 +6,7 @@ export default function LineChart({ data }: { data: any[] }) {
 
   return (
     <div className="bg-white rounded shadow p-4 h-full">
-      <h2 className="text-lg font-bold mb-2">기사 수 변화 추이</h2>
+      <h2 className="text-lg font-bold mb-2">기사 수</h2>
       <ResponsiveContainer width="100%" height={300}>
         <RechartLineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" />

--- a/frontend/src/components/TrendTab.tsx
+++ b/frontend/src/components/TrendTab.tsx
@@ -3,23 +3,25 @@ import { NavLink } from 'react-router-dom';
 
 export default function TrendTab() {
   return (
-    <div className="flex space-x-8 border-b pb-2">
-      <NavLink
-        to="/trend/weekly"
-        className={({ isActive }) =>
-          isActive ? 'border-b-2 border-black font-bold' : 'text-gray-500 visited:text-gray-500'
-        }
-      >
-        주간 이슈 변화
-      </NavLink>
-      <NavLink
-        to="/trend/search"
-        className={({ isActive }) =>
-          isActive ? 'border-b-2 border-black font-bold' : 'text-gray-500 visited:text-gray-500'
-        }
-      >
-        키워드 검색
-      </NavLink>
+    <div className="max-w-screen-xl mx-auto px-4 mt-4">
+      <div className="flex space-x-8 border-b pb-2">
+        <NavLink
+          to="/trend/weekly"
+          className={({ isActive }) =>
+            isActive ? 'border-b-2 border-black font-bold' : 'text-gray-500 visited:text-gray-500'
+          }
+        >
+          주간 이슈 변화
+        </NavLink>
+        <NavLink
+          to="/trend/search"
+          className={({ isActive }) =>
+            isActive ? 'border-b-2 border-black font-bold' : 'text-gray-500 visited:text-gray-500'
+          }
+        >
+          키워드 검색
+        </NavLink>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/card/TodayIssueCard.tsx
+++ b/frontend/src/components/card/TodayIssueCard.tsx
@@ -29,26 +29,16 @@ export default function TodayIssuePreview() {
       .catch(err => console.error(err));
   }, []);
 
-// 🔁 5초마다 index 변경 (빈 그룹 제외)
-useEffect(() => {
-  const interval = setInterval(() => {
-    setIndex((prev) => {
-      const groupCount = clusterGroups.length;
-      return groupCount === 0 ? 0 : (prev + 1) % groupCount;
-    });
-  }, 5000);
-  return () => clearInterval(interval);
-}, [clusters]);
-  
-  // 🔁 5초마다 index 변경 (정확한 그룹 수 기준으로)
+  // 🔁 5초마다 index 변경 (빈 그룹 제외)
   useEffect(() => {
-
     const interval = setInterval(() => {
-      setIndex((prev) => (prev + 1) % clusterGroups.length);
+      setIndex((prev) => {
+        const groupCount = clusterGroups.length;
+        return groupCount === 0 ? 0 : (prev + 1) % groupCount;
+      });
     }, 5000);
-
     return () => clearInterval(interval);
-  }, [clusters]); // clusters 변경 시마다 새 interval 설정
+  }, [clusters]);
 
   // 🔢 클러스터를 5개씩 묶기
   const clusterGroups: Cluster[][] = [];

--- a/frontend/src/components/card/TodayKeywordCard.tsx
+++ b/frontend/src/components/card/TodayKeywordCard.tsx
@@ -52,7 +52,7 @@ export const TodayKeywordPreview: React.FC = () => {
 
   return (
     <div className="w-full overflow-hidden">
-    <h1 className="text-2xl font-bold text-center mb-4">오늘의 키워드</h1>
+    <h1 className="text-xl font-bold text-blue-500 text-center mb-4">오늘의 키워드</h1>
     <motion.div
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}

--- a/frontend/src/components/card/WeeklyIssueCard.tsx
+++ b/frontend/src/components/card/WeeklyIssueCard.tsx
@@ -40,10 +40,10 @@ export default function WeeklyIssuePreview() {
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
       viewport={{ once: true, amount: 0.2 }}
-      className="bg-white shadow-md rounded-xl p-4"
+      className="bg-white p-4"
     >
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold text-blue-500">뉴스 트렌드</h2>
+        <h2 className="text-xl font-bold text-blue-500">뉴스 트렌드</h2>
         <button
           onClick={() => navigate("/trend")}
           className="text-sm text-blue-500 hover:underline"

--- a/frontend/src/pages/trend/KeywordIssuePage.tsx
+++ b/frontend/src/pages/trend/KeywordIssuePage.tsx
@@ -25,17 +25,6 @@ export default function KeywordIssuePage() {
       console.error("추천 키워드 로딩 실패:", err);
       setKeywords([]); // 실패해도 화면 깨지지 않도록 초기화
     });
-    // setKeywords([
-    //   "국민의 힘", "고급", "금리", "기업",
-    //   "나혼아", "나이스", "나이지리아", "네거티브", "나고야", "낭떠러지",
-    //   "더불어민주당", "두산", "대선", "대통령",
-    //   "로봇", "러시아",
-    //   "모비스", "무리",
-    //   "ㅂㅂㅂ", "ㅇㅇㅇ", "ㅇㅇㅇㅇㅇ", "ㅇㅇㅇㅇ", "ㅇㅇ", "ㅇㅇㅇ",
-    //   "사과", "소수", "사이다", "사이다", "숭례문",
-    //   "이준석", "율용도",
-    //   "트럼프", "서울", "이재명"
-    // ]);
   }, []);
 
   const getInitialSound = (str: string): string => {
@@ -104,8 +93,9 @@ export default function KeywordIssuePage() {
   const grouped = groupByInitial(keywords);
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
+    <div className="max-w-[1100px] mx-auto px-4 py-6">
       <h1 className="text-2xl font-bold mb-4 text-center">키워드 검색</h1>
+  
       {!selectedKeyword && (
         <>
           <p className="text-center text-gray-600 mb-6">
@@ -131,7 +121,7 @@ export default function KeywordIssuePage() {
           </div>
         </>
       )}
-
+  
       {selectedKeyword && (
         <div className="text-right mb-4">
           <button
@@ -146,26 +136,32 @@ export default function KeywordIssuePage() {
           </button>
         </div>
       )}
-
+  
       {loading && <p className="text-center text-gray-500">불러오는 중...</p>}
-
+  
       {selectedKeyword && !loading && trendData && (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="p-4 border rounded shadow">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr] gap-6">
+          {/* 연관 키워드 그래프 */}
+          <div className="p-4 border rounded shadow bg-white">
             <h2 className="text-lg font-semibold mb-2">연관 키워드</h2>
             <KeywordGraph clusters={clusters} />
           </div>
-          <div className="p-4 border rounded shadow">
+  
+          {/* 언급량 추이 */}
+          <div className="p-4 border rounded shadow bg-white overflow-x-auto">
             <h2 className="text-lg font-semibold mb-2">언급량 추이</h2>
-            <LineChart
-              data={trendData.daily_counts.map((d) => ({
-                date: d.date,
-                [trendData.keyword]: d.count,
-              }))}
-            />
+            <div className="min-w-[500px]">
+              <LineChart
+                data={trendData.daily_counts.map((d) => ({
+                  date: d.date,
+                  [trendData.keyword]: d.count,
+                }))}
+              />
+            </div>
           </div>
         </div>
       )}
     </div>
   );
+  
 }

--- a/frontend/src/pages/trend/TrendLayout.tsx
+++ b/frontend/src/pages/trend/TrendLayout.tsx
@@ -7,7 +7,6 @@ import Header from '@/components/Header';
 export default function TrendLayout() {
   return (
     <div >
-      
       <div class="mb-5">
       <Header />
       </div>

--- a/frontend/src/pages/trend/WeeklyIssuePage.tsx
+++ b/frontend/src/pages/trend/WeeklyIssuePage.tsx
@@ -50,7 +50,7 @@ export default function WeeklyIssuePage() {
   }, []);
 
   return (
-    <div className="grid grid-cols-5 gap-6">
+    <div className="max-w-screen-xl mx-auto px-4 grid grid-cols-5 gap-6">
       {/* 왼쪽 키워드 박스 */}
       <div className="col-span-1">
         <div className="bg-white rounded shadow p-4">
@@ -77,7 +77,7 @@ export default function WeeklyIssuePage() {
           </ul>
         </div>
       </div>
-
+  
       {/* 오른쪽 라인 차트 */}
       <div className="col-span-4">
         <LineChart data={trendData} />


### PR DESCRIPTION
### 주요 변경 사항
1. 연관 키워드 그래프 잘림 현상 수정
- 검색 키워드(selectedKeyword) 노드가 여러 개 생성되며 일부가 edge로 연결되지 않고 분리되어 보이던 문제 해결
- 중심 노드를 하나로 고정하고, 연관 키워드들을 해당 노드에만 연결되도록 수정해 중심에 고정되게 처리함
- 그래프 디자인 조금 수정

2. 상단 메뉴 탭(주간이슈변화/키워드 검색) 좌측 정렬 문제 개선
- 좌측에 메뉴가 치우쳐 있던 문제 해결

3. 주간 이슈 변화 화면 여백 추가
- 화면 좌우가 꽉 차 보여서 적절한 간격을 부여

4. 키워드 검색의 언급량 추이 그래프 잘림 현상 해결