### PR TITLE
마이페이지 헤더 오류 수정

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,7 +4,11 @@ import { Link, useNavigate } from "react-router-dom";
 import { checkAuth } from "../services/auth";
 import Logo from "@/components/ui/logo";
 
-export default function Header() {
+type HeaderProps = {
+  centerTitle?: string;
+};
+
+export default function Header({ centerTitle }: HeaderProps) {
   const navigate = useNavigate();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -28,9 +32,19 @@ export default function Header() {
   };
 
   return (
-     <header className="w-full bg-black text-white px-10 py-10 flex items-center justify-between shadow-md z-50 sticky top-0 h-28">
-      <Logo />
-      <nav className="flex items-center gap-6 text-lg font-medium">
+    <header className="w-full bg-black text-white px-10 py-6 flex items-center justify-between relative shadow-md z-50 sticky top-0 h-28">
+      <div className="z-10">
+        <Logo />
+      </div>
+
+      {/* ✅ 중앙 제목 */}
+      {centerTitle && (
+        <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl font-bold text-white">
+          {centerTitle}
+        </h1>
+      )}
+
+      <nav className="flex items-center gap-6 text-lg font-medium z-10">
         <Link to="/today/issue" className="hover:text-orange-300 transition">오늘의 이슈</Link>
         <Link to="/trend/weekly" className="hover:text-orange-300 transition">트렌드</Link>
         {isLoggedIn ? (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -40,20 +40,11 @@ export default function DashboardPage() {
   return (
     
     <div className="min-h-screen flex flex-col justify-start">
-          <header className="h-25 bg-blue-500 text-white px-6 flex items-center justify-between mb-10">
-            <div className="flex items-center">
-              <Logo />
-            </div>
-            <h1 className="text-white text-4xl font-bmjua">
-              MY PAGE
-            </h1>
-            <div className="px-2 py -1">
-              <Header />
-            </div>
-          </header>
+      {/* ✅ 중앙 제목을 props로 전달 */}
+      <Header centerTitle="MY PAGE" />
 
       {/* ✅ 본문 (세로 정렬) */}
-      <main className="px-6 flex flex-col items-center gap-10">
+      <main className="mt-10 px-6 flex flex-col items-center gap-10">
         {/* ✅ 지식맵 */}
         <section className="w-full max-w-5xl">
           <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
<img width="1680" alt="스크린샷 2025-06-14 오후 1 22 51" src="https://github.com/user-attachments/assets/ee6d3b52-07f4-4cd2-9327-010e7607c610" />
원래 마이페이지 헤더가 이런식으로 깨졌는데 아래처럼 고침
<img width="1680" alt="스크린샷 2025-06-14 오후 1 42 54" src="https://github.com/user-attachments/assets/57152ba9-87cb-45c5-8431-60cebf90ab21" />

### 주요 변경 사항
- 컴포넌트인 Header.tsx에서 centerTitle을 Props로 받도록 수정
- DashboardPage에서 Header 생성할 때 타이틀로 "MY PAGE"를 넘기는 구조로 바꿈
- title 안 주면 그냥 타이틀 없는채로 정상 렌더링 됨

### 기타
다른 오늘의 이슈 페이지나 뉴스트렌드 페이지도 같은 형식으로 타이틀 줄지 결정..? 일단 없는게 깔끔해보여서 안 고쳤어요