### PR TITLE
ADD : 동일 키워드의 클러스터 중복 필터링

### DIFF
--- a/project/api/create_app.py
+++ b/project/api/create_app.py
@@ -107,7 +107,7 @@ def create_app():
         # 1) Redis 연결 및 캐시 초기화
         redis_client = Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_DB)
         FastAPICache.init(RedisBackend(redis_client), prefix="fastapi-cache")
-    
+        await FastAPICache.clear()
         # 2) 기존 스케줄러·파이프라인
         # 서버 구동 시 한 번만 스케줄러 시작
         scheduler.start()  


### PR DESCRIPTION
## 주요 변경 사항
### 1. api/utils/cluster 파일에 동일 대표 키워드를 가지는 클러스터 중복 필터링 로직 구현
- clusters/today & /trends/search 엔드포인트에서 동일 대표 키워드를 가지는 클러스터들에 대해 해당 로직 적용
### 2. 서버 재구동시 redis 캐시 clear 추가
- 개발 환경을 위해..
### 3. trends/ 엔드포인트 쪽 KST 적용
- 자정이 되어도 날짜가 바뀌지 않던 문제 (6/7 ~ 6/13 에서 6/8 ~ 6/14) 해결